### PR TITLE
Fix compilation issue for x64 hardware

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/QuickBirdEng/crc-swift.git",
         "state": {
           "branch": null,
-          "revision": "136db0392ff9afdd1fe51bc1fdc05aaf7585bc88",
-          "version": "0.1.0"
+          "revision": "0616be13dec7b6dc4b55e266cba39c1772902b08",
+          "version": "0.1.1"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/QuickBirdEng/crc-swift.git",
-            from: "0.1.0"
+            from: "0.1.1"
         ),
     ],
     targets: [

--- a/Sources/DataKit/Values/ReadWritable+FloatingPoint.swift
+++ b/Sources/DataKit/Values/ReadWritable+FloatingPoint.swift
@@ -14,8 +14,11 @@ public protocol FixedWidthFloatingPoint: BinaryFloatingPoint {
     var bitPattern: BitPattern { get }
 }
 
+#if arch(arm64)
 @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
 extension Float16: FixedWidthFloatingPoint, ReadWritable {}
+#endif
+
 extension Float32: FixedWidthFloatingPoint, ReadWritable {}
 extension Float64: FixedWidthFloatingPoint, ReadWritable {}
 


### PR DESCRIPTION
As explained in [Float16](https://developer.apple.com/documentation/swift/float16) documentation, the type is only available when targetting Apple Silicon hardware.

The `@available` directive is not enough to ignore this function on x64 hardware, causing compilation errors.

This PR comes with [a twin](https://github.com/QuickBirdEng/crc-swift/pull/2) on the crc-swift repository.